### PR TITLE
add_city.sh: Fix adding phone codes

### DIFF
--- a/source/add_city.sh
+++ b/source/add_city.sh
@@ -6,7 +6,8 @@ city_definition="${1}"
 	country_code=$(echo "$city_definition" | awk -F'|' '{ print $2 } ')
 	city=$(echo "$city_definition" | awk -F'|' '{ print $3 } ')
 	timezone=$(echo "$city_definition" | awk -F'|' '{ print $4 } ')
-	phone_code="$(curl --connect-timeout 20 -s https://restcountries.eu/rest/v2/alpha/$country_code | python -c 'import sys, json; print json.load(sys.stdin)["callingCodes"][0]')"
+        all_phone_codes="$(curl --connect-timeout 20 --silent http://country.io/phone.json)"
+	phone_code="$(osascript -l JavaScript -e 'function run(argv) { return JSON.parse(argv[0])[argv[1]] }' "${all_phone_codes}" "${country_code}")"
 
 	echo "$city|$country|$timezone|$country_code|$phone_code|1" >> "$timezone_file"
 	sort -o "${timezone_file}.new" "$timezone_file" 


### PR DESCRIPTION
This workflow was [suggested as an addition](https://www.alfredforum.com/topic/19109-timezones-a-world-clock/) to [the upcoming Alfred Gallery](https://www.alfredforum.com/topic/19058-submitting-workflows-for-the-alfred-gallery/), and while reviewing I noticed adding new cities wasn’t working.

The URL being queried is dead. But even if it wasn’t, the `python` call wouldn’t work out of the box for people with macOS 12.3 or later. This all results in a 20 second wait and an error every time, in which it feels as if the workflow doesn’t work.

This PR adds a working URL and uses JavaScript for Automation (which ships with macOS) to get the country phone code. I’m doing it this way for consistency with the previous code, but I’d recommend just adding the list of phone codes as an extra file in the workflow. After all, it’s not like those change.