### PR TITLE
Fix issue #63 with updater running and nothing to do (on v2.61) via updating info.plist 

### DIFF
--- a/source/info.plist
+++ b/source/info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>bundleid</key>
 	<string>carlosnz.timezones2</string>
+	<key>category</key>
+	<string>Productivity</string>
 	<key>connections</key>
 	<dict>
 		<key>16D7BCC0-AD0A-49B7-98F2-5FC3444910B1</key>
@@ -1203,7 +1205,7 @@
 				<key>escaping</key>
 				<integer>0</integer>
 				<key>script</key>
-				<string>./oneUpdater.sh 0</string>
+				<string>./oneUpdater.sh 30</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>
@@ -1221,7 +1223,7 @@
 	</array>
 	<key>readme</key>
 	<string># TimeZones
-Latst update: 25 February 2024
+Latst update: 18 April 2024
 
 # USAGE
 
@@ -1248,6 +1250,11 @@ Latst update: 25 February 2024
 # CHANGELOG
 
 All issues tracked on GitHub https://github.com/jaroslawhartman/TimeZones-Alfred/issues
+
+## 2.61
+18 April 2024
+
+* Added support for abbreviated timezones #61
 
 ## 2.60
 25 February 2024
@@ -1697,7 +1704,7 @@ Fixes after google deprecating their map APIs.
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>2.60</string>
+	<string>2.61</string>
 	<key>webaddress</key>
 	<string>https://jhartman.pl/tag/time-zones/</string>
 </dict>


### PR DESCRIPTION
Addressed the issue #63 where the updater, every time it's run, tries to install the same version that's already present as the comparison is done with an older version of info.plist

I've just added to my fork/branch the 2.61 version of the workflow as installed by the updater